### PR TITLE
BEG-137: Move recaching to queue consumer changes

### DIFF
--- a/Api/Data/PrerenderRecachingManagementRequestInterface.php
+++ b/Api/Data/PrerenderRecachingManagementRequestInterface.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Aligent Consulting
+ * Copyright (c) Aligent Consulting (https://www.aligent.com.au)
+ */
+
+declare(strict_types=1);
+
+namespace Aligent\Prerender\Api\Data;
+
+interface PrerenderRecachingManagementRequestInterface
+{
+    public const BATCH_URLS = "batch_urls";
+    public const STORE_ID = "store_id";
+    public const INDEXER_ID = "indexer_id";
+
+    /**
+     * Get Batch Urls
+     *
+     * @return string
+     */
+    public function getBatchUrls(): string;
+
+    /**
+     * Set Batch Urls
+     *
+     * @param string $batchUrls
+     * @return void
+     */
+    public function setBatchUrls(string $batchUrls): void;
+
+    /**
+     * Get Store Id
+     *
+     * @return int
+     */
+    public function getStoreId(): int;
+
+    /**
+     * Set Store Id
+     *
+     * @param int $storeId
+     * @return void
+     */
+    public function setStoreId(int $storeId): void;
+
+    /**
+     * Get Indexer Id
+     *
+     * @return string
+     */
+    public function getIndexerId(): string;
+
+    /**
+     * Set Indexer Id
+     *
+     * @param string $indexerId
+     * @return void
+     */
+    public function setIndexerId(string $indexerId): void;
+}

--- a/Api/PrerenderRecachingManagementInterface.php
+++ b/Api/PrerenderRecachingManagementInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Aligent Consulting
+ * Copyright (c) Aligent Consulting (https://www.aligent.com.au)
+ */
+
+declare(strict_types=1);
+
+namespace Aligent\Prerender\Api;
+
+use Aligent\Prerender\Api\Data\PrerenderRecachingManagementRequestInterface;
+use DOMException;
+
+interface PrerenderRecachingManagementInterface
+{
+
+    /**
+     * Recache Urls
+     *
+     * @param PrerenderRecachingManagementRequestInterface $prerenderRecachingManagementRequest
+     * @return string
+     */
+    public function recacheUrls(PrerenderRecachingManagementRequestInterface $prerenderRecachingManagementRequest): string;
+}

--- a/Model/Api/Data/PrerenderRecachingManagementRequest.php
+++ b/Model/Api/Data/PrerenderRecachingManagementRequest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Aligent Consulting
+ * Copyright (c) 2023 Aligent Consulting. (https://www.aligent.com.au)
+ */
+
+declare(strict_types=1);
+
+namespace Aligent\Prerender\Model\Api\Data;
+
+use Aligent\Prerender\Api\Data\PrerenderRecachingManagementRequestInterface;
+use Magento\Framework\DataObject;
+
+class PrerenderRecachingManagementRequest extends DataObject implements PrerenderRecachingManagementRequestInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function getBatchUrls(): string
+    {
+        return $this->getData(self::BATCH_URLS);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBatchUrls(string $batchUrls): void
+    {
+        $this->setData(self::BATCH_URLS, $batchUrls);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStoreId(): int
+    {
+        return $this->getData(self::STORE_ID);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setStoreId(int $storeId): void
+    {
+        $this->setData(self::STORE_ID, $storeId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIndexerId(): string
+    {
+        return $this->getData(self::INDEXER_ID);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setIndexerId(string $indexerId): void
+    {
+        $this->setData(self::INDEXER_ID, $indexerId);
+    }
+}

--- a/Model/Api/PrerenderRecachingManagement.php
+++ b/Model/Api/PrerenderRecachingManagement.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Aligent Consulting
+ * Copyright (c) 2023 Aligent Consulting. (https://www.aligent.com.au)
+ */
+
+declare(strict_types=1);
+
+namespace Aligent\Prerender\Model\Api;
+
+use Magento\Framework\Exception\BulkException;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Aligent\Prerender\Api\PrerenderRecachingManagementInterface;
+use Aligent\Prerender\Api\Data\PrerenderRecachingManagementRequestInterface;
+use Aligent\Prerender\Api\PrerenderClientInterface;
+use Magento\Sales\Model\Order;
+use Exception;
+use DOMDocument;
+use DOMException;
+use Magento\Store\Model\App\Emulation;
+use Magento\Framework\Escaper;
+use Magento\Framework\Stdlib\DateTime\DateTime;
+use Magento\Directory\Model\CountryFactory;
+use Magento\Framework\Exception\CouldNotSaveException;
+
+class PrerenderRecachingManagement implements PrerenderRecachingManagementInterface
+{
+
+    /**
+     * @param PrerenderClientInterface $prerenderClient
+     * @param Json $json
+     */
+    public function __construct(
+        private readonly PrerenderClientInterface $prerenderClient,
+        private readonly Json $json,
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function recacheUrls(
+        PrerenderRecachingManagementRequestInterface $prerenderRecachingManagementRequest
+    ): string {
+        $message = "";
+        try {
+            $this->prerenderClient->recacheUrls(
+                $this->json->unserialize($prerenderRecachingManagementRequest->getBatchUrls()),
+                $prerenderRecachingManagementRequest->getStoreId()
+            );
+            $message = 'INFO: Recaching Urls successfully synced for ' .
+                $prerenderRecachingManagementRequest->getIndexerId();
+        } catch (Exception $exception) {
+            $message = 'ERROR: There was an error syncing the Recaching Urls for ' .
+                $prerenderRecachingManagementRequest->getIndexerId() . $exception->getMessage();
+        }
+        return $message;
+    }
+}

--- a/Model/Indexer/Category/ProductIndexer.php
+++ b/Model/Indexer/Category/ProductIndexer.php
@@ -7,10 +7,12 @@ declare(strict_types=1);
 
 namespace Aligent\Prerender\Model\Indexer\Category;
 
+use Aligent\Prerender\Api\Data\PrerenderRecachingManagementRequestInterfaceFactory as PrerenderRecachingManagementRequest;
 use Aligent\Prerender\Api\PrerenderClientInterface;
 use Aligent\Prerender\Helper\Config;
 use Aligent\Prerender\Model\Indexer\DataProvider\ProductCategories;
 use Aligent\Prerender\Model\Url\GetUrlsForCategories;
+use Magento\AsynchronousOperations\Model\MassSchedule;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Exception\LocalizedException;
@@ -19,6 +21,7 @@ use Magento\Framework\Indexer\ActionInterface as IndexerActionInterface;
 use Magento\Framework\Indexer\DimensionalIndexerInterface;
 use Magento\Framework\Indexer\DimensionProviderInterface;
 use Magento\Framework\Mview\ActionInterface as MviewActionInterface;
+use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Store\Model\StoreDimensionProvider;
 
 class ProductIndexer implements IndexerActionInterface, MviewActionInterface, DimensionalIndexerInterface
@@ -26,18 +29,6 @@ class ProductIndexer implements IndexerActionInterface, MviewActionInterface, Di
     private const INDEXER_ID = 'prerender_category_product';
     private const DEPLOYMENT_CONFIG_INDEXER_BATCHES = 'indexer/batch_size/';
 
-    /** @var DimensionProviderInterface  */
-    private DimensionProviderInterface $dimensionProvider;
-    /** @var ProductCategories */
-    private ProductCategories $productCategoriesDataProvider;
-    /** @var GetUrlsForCategories  */
-    private GetUrlsForCategories $getUrlsForCategories;
-    /** @var PrerenderClientInterface  */
-    private PrerenderClientInterface $prerenderClient;
-    /** @var DeploymentConfig  */
-    private DeploymentConfig $eploymentConfig;
-    /** @var Config  */
-    private Config $prerenderConfigHelper;
     /** @var int|null  */
     private ?int $batchSize;
 
@@ -52,21 +43,18 @@ class ProductIndexer implements IndexerActionInterface, MviewActionInterface, Di
      * @param int|null $batchSize
      */
     public function __construct(
-        DimensionProviderInterface $dimensionProvider,
-        ProductCategories $productCategoriesDataProvider,
-        GetUrlsForCategories $getUrlsForCategories,
-        PrerenderClientInterface $prerenderClient,
-        DeploymentConfig $deploymentConfig,
-        Config $prerenderConfigHelper,
+        private readonly DimensionProviderInterface $dimensionProvider,
+        private readonly ProductCategories $productCategoriesDataProvider,
+        private readonly GetUrlsForCategories $getUrlsForCategories,
+        private readonly PrerenderClientInterface $prerenderClient,
+        private readonly DeploymentConfig $deploymentConfig,
+        private readonly Config $prerenderConfigHelper,
+        private readonly PrerenderRecachingManagementRequest $prerenderRecachingManagementRequest,
+        private readonly MassSchedule $massSchedule,
+        private readonly Json $json,
         ?int $batchSize = 1000
     ) {
-        $this->dimensionProvider = $dimensionProvider;
-        $this->productCategoriesDataProvider = $productCategoriesDataProvider;
-        $this->getUrlsForCategories = $getUrlsForCategories;
-        $this->prerenderClient = $prerenderClient;
-        $this->deploymentConfig = $deploymentConfig;
         $this->batchSize = $batchSize;
-        $this->prerenderConfigHelper = $prerenderConfigHelper;
     }
 
     /**
@@ -156,7 +144,11 @@ class ProductIndexer implements IndexerActionInterface, MviewActionInterface, Di
 
         $urlBatches = array_chunk($urls, $this->batchSize);
         foreach ($urlBatches as $batchUrls) {
-            $this->prerenderClient->recacheUrls($batchUrls, $storeId);
+            $request = $this->prerenderRecachingManagementRequest->create();
+            $request->setBatchUrls($this->json->serialize($batchUrls));
+            $request->setStoreId((int) $storeId);
+            $request->setIndexerId(self::INDEXER_ID);
+            $this->massSchedule->publishMass('asynchronous.prerender.recaching', [[$request]]);
         }
     }
 }

--- a/etc/communication.xml
+++ b/etc/communication.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Communication/etc/communication.xsd">
+    <topic name="asynchronous.prerender.recaching"
+           schema="Aligent\Prerender\Api\PrerenderRecachingManagementInterface::recacheUrls"
+           is_synchronous="false">
+        <handler name="async" type="Aligent\Prerender\Api\PrerenderRecachingManagementInterface"
+                 method="recacheUrls"/>
+    </topic>
+</config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -7,6 +7,10 @@
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Aligent\Prerender\Api\PrerenderClientInterface"
                 type="Aligent\Prerender\Model\Api\PrerenderClient"/>
+    <preference for="Aligent\Prerender\Api\PrerenderRecachingManagementInterface"
+                type="Aligent\Prerender\Model\Api\PrerenderRecachingManagement"/>
+    <preference for="Aligent\Prerender\Api\Data\PrerenderRecachingManagementRequestInterface"
+                type="Aligent\Prerender\Model\Api\Data\PrerenderRecachingManagementRequest"/>
     <type name="Aligent\Prerender\Model\Indexer\Product\ProductIndexer">
         <arguments>
             <argument name="dimensionProvider" xsi:type="object" shared="false">

--- a/etc/queue_consumer.xml
+++ b/etc/queue_consumer.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/consumer.xsd">
+    <consumer name="prerender.recaching.handler"
+              queue="prerender.recaching"
+              connection="amqp"
+              consumerInstance="Magento\AsynchronousOperations\Model\MassConsumer"
+              onlySpawnWhenMessageAvailable="0"
+              maxMessages="5000"
+    />
+</config>

--- a/etc/queue_publisher.xml
+++ b/etc/queue_publisher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/publisher.xsd">
+    <publisher topic="asynchronous.prerender.recaching">
+        <connection name="amqp" exchange="magento" disabled="false" />
+    </publisher>
+</config>

--- a/etc/queue_topology.xml
+++ b/etc/queue_topology.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/topology.xsd">
+    <exchange name="magento" type="topic" connection="amqp">
+        <binding id="PrerenderRecaching"
+                 topic="asynchronous.prerender.recaching"
+                 destinationType="queue"
+                 destination="prerender.recaching"
+        />
+    </exchange>
+</config>


### PR DESCRIPTION
This PR content following changes.

- Create new queue consumer for prerender recaching
- Once the reindex process happened for prerender_product, prerender_category, prerender_category_product indexers execute recaching via queue consumer.