### PR TITLE
Fix typo in class property

### DIFF
--- a/Model/Indexer/Product/ProductIndexer.php
+++ b/Model/Indexer/Product/ProductIndexer.php
@@ -33,7 +33,7 @@ class ProductIndexer implements IndexerActionInterface, MviewActionInterface, Di
     /** @var PrerenderClientInterface  */
     private PrerenderClientInterface $prerenderClient;
     /** @var DeploymentConfig  */
-    private DeploymentConfig $eploymentConfig;
+    private DeploymentConfig $deploymentConfig;
     /** @var Config  */
     private Config $prerenderConfigHelper;
     /** @var Configurable */


### PR DESCRIPTION
Not actually a functional problem at the moment - just means the property gets declared dynamically in the constructor. But, we want to not have that happen.