### PR TITLE
Fixed the property name to deploymentConfig

### DIFF
--- a/Model/Indexer/Category/CategoryIndexer.php
+++ b/Model/Indexer/Category/CategoryIndexer.php
@@ -32,7 +32,7 @@ class CategoryIndexer implements IndexerActionInterface, MviewActionInterface, D
     /** @var PrerenderClientInterface  */
     private PrerenderClientInterface $prerenderClient;
     /** @var DeploymentConfig  */
-    private DeploymentConfig $eploymentConfig;
+    private DeploymentConfig $deploymentConfig;
     /** @var Config  */
     private Config $prerenderConfigHelper;
     /** @var int|null  */

--- a/Model/Indexer/Category/ProductIndexer.php
+++ b/Model/Indexer/Category/ProductIndexer.php
@@ -36,7 +36,7 @@ class ProductIndexer implements IndexerActionInterface, MviewActionInterface, Di
     /** @var PrerenderClientInterface  */
     private PrerenderClientInterface $prerenderClient;
     /** @var DeploymentConfig  */
-    private DeploymentConfig $eploymentConfig;
+    private DeploymentConfig $deploymentConfig;
     /** @var Config  */
     private Config $prerenderConfigHelper;
     /** @var Configurable */


### PR DESCRIPTION
Fix for the following issue in 2.4.8-beta2

`==> var/log/cron.log <== [2025-01-29T04:51:14.669380+00:00] report.ERROR: Cron Job indexer_update_all_views has an error: Deprecated Functionality: Creation of dynamic property Aligent\Prerender\Model\Indexer\Category\CategoryIndexer\Interceptor::$deploymentConfig is deprecated in /app/e2x2k5zul7d42_stg/vendor/aligent/magento2-prerender/Model/Indexer/Category/CategoryIndexer.php on line 61. Statistics: {"sum":0,"count":1,"realmem":0,"emalloc":0,"realmem_start":339214336,"emalloc_start":316141136} [] []

==> var/log/support_report.log <== [2025-01-29T04:51:14.709207+00:00] report.CRITICAL: Exception: Deprecated Functionality: Creation of dynamic property Aligent\Prerender\Model\Indexer\Category\CategoryIndexer\Interceptor::$deploymentConfig is deprecated in /app/e2x2k5zul7d42_stg/vendor/aligent/magento2-prerender/Model/Indexer/Category/CategoryIndexer.php on line 61 in /app/e2x2k5zul7d42_stg/vendor/magento/framework/App/ErrorHandler.php:62 Stack trace: #0 /app/e2x2k5zul7d42_stg/vendor/aligent/magento2-prerender/Model/Indexer/Category/CategoryIndexer.php(61): Magento\Framework\App\ErrorHandler->handler() #1 `