### PR TITLE
Feature/beg 202 include missing features in aligent magento2 prerender module

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -15,6 +15,7 @@ class Config
     private const XML_PATH_RECACHE_ENABLED = 'system/prerender/enabled';
     private const XML_PATH_PRERENDER_TOKEN = 'system/prerender/token';
     private const XML_PATH_RECACHE_SERVICE_URL = 'system/prerender/service_url';
+    private const XML_PATH_PRERENDER_USE_PRODUCT_CANONICAL_URL = 'system/prerender/use_product_canonical_url';
 
     /** @var ScopeConfigInterface  */
     private ScopeConfigInterface $scopeConfig;
@@ -38,7 +39,7 @@ class Config
     {
         return $this->scopeConfig->isSetFlag(
             self::XML_PATH_RECACHE_ENABLED,
-            ScopeInterface::SCOPE_STORE,
+            ScopeInterface::SCOPE_STORES,
             $storeId
         );
     }
@@ -72,4 +73,20 @@ class Config
             $storeId
         );
     }
+
+    /**
+     * Return if product canonical url configuration is enabled or not
+     *
+     * @param int|null $storeId
+     * @return bool
+     */
+    public function isUseProductCanonicalUrlEnabled(?int $storeId = null): bool
+    {
+        return $this->scopeConfig->isSetFlag(
+            self::XML_PATH_PRERENDER_USE_PRODUCT_CANONICAL_URL,
+            ScopeInterface::SCOPE_STORES,
+            $storeId
+        );
+    }
+
 }

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -16,6 +16,9 @@ class Config
     private const XML_PATH_PRERENDER_TOKEN = 'system/prerender/token';
     private const XML_PATH_RECACHE_SERVICE_URL = 'system/prerender/service_url';
     private const XML_PATH_PRERENDER_USE_PRODUCT_CANONICAL_URL = 'system/prerender/use_product_canonical_url';
+    private const XML_PATH_RECACHE_PRODUCT_ENABLED = 'system/prerender/enable_product_indexing';
+    private const XML_PATH_RECACHE_PRODUCT_CATEGORY_ENABLED = 'system/prerender/enable_product_category_indexing';
+    private const XML_PATH_RECACHE_CATEGORY_ENABLED = 'system/prerender/enable_category_indexing';
 
     /** @var ScopeConfigInterface  */
     private ScopeConfigInterface $scopeConfig;
@@ -89,4 +92,48 @@ class Config
         );
     }
 
+    /**
+     * Return if re-caching functionality is enabled for product only indexer
+     *
+     * @param int|null $storeId
+     * @return bool
+     */
+    public function isProductRecacheEnabled(?int $storeId = null): bool
+    {
+        return $this->scopeConfig->isSetFlag(
+            self::XML_PATH_RECACHE_PRODUCT_ENABLED,
+            ScopeInterface::SCOPE_STORES,
+            $storeId
+        );
+    }
+
+    /**
+     * Return if re-caching functionality is enabled for product-category mapping indexer
+     *
+     * @param int|null $storeId
+     * @return bool
+     */
+    public function isProductCategoryRecacheEnabled(?int $storeId = null): bool
+    {
+        return $this->scopeConfig->isSetFlag(
+            self::XML_PATH_RECACHE_PRODUCT_CATEGORY_ENABLED,
+            ScopeInterface::SCOPE_STORES,
+            $storeId
+        );
+    }
+
+    /**
+     * Return if re-caching functionality is enabled for category only indexer
+     *
+     * @param int|null $storeId
+     * @return bool
+     */
+    public function isCategoryRecacheEnabled(?int $storeId = null): bool
+    {
+        return $this->scopeConfig->isSetFlag(
+            self::XML_PATH_RECACHE_CATEGORY_ENABLED,
+            ScopeInterface::SCOPE_STORES,
+            $storeId
+        );
+    }
 }

--- a/Model/Indexer/Category/CategoryIndexer.php
+++ b/Model/Indexer/Category/CategoryIndexer.php
@@ -121,7 +121,7 @@ class CategoryIndexer implements IndexerActionInterface, MviewActionInterface, D
     /**
      * Execute indexing per dimension (store)
      *
-     * @param arry $dimensions
+     * @param array $dimensions
      * @param \Traversable $entityIds
      * @throws FileSystemException
      * @throws RuntimeException
@@ -133,7 +133,8 @@ class CategoryIndexer implements IndexerActionInterface, MviewActionInterface, D
         }
         $storeId = (int)$dimensions[StoreDimensionProvider::DIMENSION_NAME]->getValue();
 
-        if (!$this->prerenderConfigHelper->isRecacheEnabled($storeId)) {
+        if (!$this->prerenderConfigHelper->isRecacheEnabled($storeId)
+            || !$this->prerenderConfigHelper->isCategoryRecacheEnabled($storeId)) {
             return;
         }
 

--- a/Model/Indexer/Category/ProductIndexer.php
+++ b/Model/Indexer/Category/ProductIndexer.php
@@ -133,7 +133,7 @@ class ProductIndexer implements IndexerActionInterface, MviewActionInterface, Di
     /**
      * Execute indexing per dimension (store)
      *
-     * @param arry $dimensions
+     * @param array $dimensions
      * @param \Traversable $entityIds
      * @throws FileSystemException
      * @throws RuntimeException
@@ -145,7 +145,8 @@ class ProductIndexer implements IndexerActionInterface, MviewActionInterface, Di
         }
         $storeId = (int)$dimensions[StoreDimensionProvider::DIMENSION_NAME]->getValue();
 
-        if (!$this->prerenderConfigHelper->isRecacheEnabled($storeId)) {
+        if (!$this->prerenderConfigHelper->isRecacheEnabled($storeId)
+            || !$this->prerenderConfigHelper->isProductCategoryRecacheEnabled($storeId)) {
             return;
         }
 

--- a/Model/Indexer/Product/ProductIndexer.php
+++ b/Model/Indexer/Product/ProductIndexer.php
@@ -127,7 +127,7 @@ class ProductIndexer implements IndexerActionInterface, MviewActionInterface, Di
     /**
      * Execute indexing per dimension (store)
      *
-     * @param arry $dimensions
+     * @param array $dimensions
      * @param \Traversable $entityIds
      * @throws FileSystemException
      * @throws RuntimeException
@@ -139,7 +139,8 @@ class ProductIndexer implements IndexerActionInterface, MviewActionInterface, Di
         }
         $storeId = (int)$dimensions[StoreDimensionProvider::DIMENSION_NAME]->getValue();
 
-        if (!$this->prerenderConfigHelper->isRecacheEnabled($storeId)) {
+        if (!$this->prerenderConfigHelper->isRecacheEnabled($storeId)
+            || !$this->prerenderConfigHelper->isProductRecacheEnabled($storeId)) {
             return;
         }
 

--- a/Model/Url/GetUrlsForProducts.php
+++ b/Model/Url/GetUrlsForProducts.php
@@ -20,17 +20,41 @@ class GetUrlsForProducts
     private const DELIMETER = "?";
 
     /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var Emulation
+     */
+    private $emulation;
+
+    /**
+     * @var UrlFinderInterface
+     */
+    private $urlFinder;
+
+    /**
+     * @var Config
+     */
+    private $prerenderConfigHelper;
+
+    /**
      * @param StoreManagerInterface $storeManager
      * @param Emulation $emulation
      * @param UrlFinderInterface $urlFinder
      * @param Config $prerenderConfigHelper
      */
     public function __construct(
-        private readonly StoreManagerInterface $storeManager,
-        private readonly Emulation $emulation,
-        private readonly UrlFinderInterface $urlFinder,
-        private readonly Config $prerenderConfigHelper,
+        StoreManagerInterface $storeManager,
+        Emulation $emulation,
+        UrlFinderInterface $urlFinder,
+        Config $prerenderConfigHelper
     ) {
+        $this->storeManager = $storeManager;
+        $this->emulation = $emulation;
+        $this->urlFinder = $urlFinder;
+        $this->prerenderConfigHelper = $prerenderConfigHelper;
     }
 
     /**

--- a/Model/Url/GetUrlsForProducts.php
+++ b/Model/Url/GetUrlsForProducts.php
@@ -7,38 +7,30 @@ declare(strict_types=1);
 
 namespace Aligent\Prerender\Model\Url;
 
-use Magento\Catalog\Model\Product;
-use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\App\Emulation;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\UrlRewrite\Controller\Adminhtml\Url\Rewrite;
+use Magento\UrlRewrite\Model\UrlFinderInterface;
+use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 
 class GetUrlsForProducts
 {
     private const DELIMETER = "?";
 
-    /** @var CollectionFactory  */
-    private CollectionFactory $productCollectionFactory;
-    /** @var StoreManagerInterface */
-    private StoreManagerInterface $storeManager;
-    /** @var Emulation */
-    private Emulation $emulation;
-
     /**
-     *
-     * @param CollectionFactory $productCollectionFactory
      * @param StoreManagerInterface $storeManager
      * @param Emulation $emulation
+     * @param UrlFinderInterface $urlFinder
+     * @param Config $prerenderConfigHelper
      */
     public function __construct(
-        CollectionFactory $productCollectionFactory,
-        StoreManagerInterface $storeManager,
-        Emulation $emulation
+        private readonly StoreManagerInterface $storeManager,
+        private readonly Emulation $emulation,
+        private readonly UrlFinderInterface $urlFinder,
+        private readonly Config $prerenderConfigHelper,
     ) {
-        $this->productCollectionFactory = $productCollectionFactory;
-        $this->storeManager = $storeManager;
-        $this->emulation = $emulation;
     }
 
     /**
@@ -50,16 +42,6 @@ class GetUrlsForProducts
      */
     public function execute(array $productIds, int $storeId): array
     {
-        $productCollection = $this->productCollectionFactory->create();
-        // do not ignore out of stock products
-        $productCollection->setFlag('has_stock_status_filter', true);
-        // if array of product ids is empty, just load all products
-        if (!empty($productIds)) {
-            $productCollection->addIdFilter($productIds);
-        }
-        $productCollection->setStoreId($storeId);
-        $productCollection->addUrlRewrite();
-
         try {
             /** @var Store $store */
             $store = $this->storeManager->getStore($storeId);
@@ -67,17 +49,30 @@ class GetUrlsForProducts
             return [];
         }
 
+        $useProductCanonical = $this->prerenderConfigHelper->isUseProductCanonicalUrlEnabled($storeId);
+
+        $findByData = [
+            UrlRewrite::ENTITY_TYPE => Rewrite::ENTITY_TYPE_PRODUCT,
+            UrlRewrite::STORE_ID => $storeId,
+            UrlRewrite::ENTITY_ID =>  $productIds
+        ];
+
+        $urlRewrites = $this->urlFinder->findAllByData($findByData);
         $this->emulation->startEnvironmentEmulation($storeId);
         $urls = [];
         /** @var Product $product */
-        foreach ($productCollection as $product) {
-            $urlPath = $product->getData('request_path');
-            if (empty($urlPath)) {
+        foreach ($urlRewrites as $urlRewrite) {
+            if (empty($urlRewrite->getRequestPath())) {
                 continue;
             }
+            // Ignore the product URL with category path.
+            if ($useProductCanonical && $urlRewrite->getMetadata()) {
+                continue;
+            }
+
             try {
                 // Retrieve URL using store configuration
-                $url = $store->getUrl('', ['_direct' => $urlPath]);
+                $url = $store->getUrl('', ['_direct' => $urlRewrite->getRequestPath()]);
 
                 // Remove trailing slashes from urls
                 $urls[] = rtrim($url, '/');

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -31,6 +31,30 @@
                     <comment>Ignore the non-canonical URLs which includes category paths for products.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="enable_product_indexing" translate="label comment" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Recache product URLs</label>
+                    <comment>Product updates will recache PDPs.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
+                <field id="enable_product_category_indexing" translate="label comment" type="select" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Recache product's category URLs</label>
+                    <comment>Product updates will recache linked category PLPs.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
+                <field id="enable_category_indexing" translate="label comment" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Recache category URLs</label>
+                    <comment>Category updates will recache PLPs.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
             </group>
         </section>
     </system>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -26,6 +26,11 @@
                         <field id="enabled">1</field>
                     </depends>
                 </field>
+                <field id="use_product_canonical_url" translate="label comment" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Use Canonical URL For Products</label>
+                    <comment>Ignore the non-canonical URLs which includes category paths for products.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
         </section>
     </system>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -6,6 +6,7 @@
             <prerender>
                 <enabled>0</enabled>
                 <service_url><![CDATA[https://api.prerender.io/recache]]></service_url>
+                <use_product_canonical_url>0</use_product_canonical_url>
             </prerender>
         </system>
     </default>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -7,6 +7,9 @@
                 <enabled>0</enabled>
                 <service_url><![CDATA[https://api.prerender.io/recache]]></service_url>
                 <use_product_canonical_url>0</use_product_canonical_url>
+                <enable_product_indexing>1</enable_product_indexing>
+                <enable_product_category_indexing>1</enable_product_category_indexing>
+                <enable_category_indexing>1</enable_category_indexing>
             </prerender>
         </system>
     </default>


### PR DESCRIPTION
**Note to Reviewers:** 

These changes are implemented based on these PRs from original repo (no longer actively maintained)
1. https://github.com/aligent/magento2-prerender-io/pull/20
2. https://github.com/aligent/magento2-prerender-io/pull/13

**Problem:**

1. “Option to Ignore the non-canonical URLs which includes category paths for products" feature is currently missing from the forked repository [GitHub - aligent/magento2-prerender: Provides automatic recaching of URLs within Prerender](https://github.com/aligent/magento2-prerender/tree/main) , which is now the actively maintained version. The original module (aligent/magento2-prerender-io) is no longer maintained but does include this functionality.
2. Feature that allows admin to disable indexer via Admin Configuration is missing from aligent/magento2-prerender module


**Solution Implemented**

1. Allow admin to disable indexers via Admin Configuration
2. Add "Option to Ignore the non-canonical URLs which includes category paths for products" feature in aligent/magento2-prerender module too


Time Tracking: BEG-202: Code Review

Issue: https://github.com/aligent/magento2-prerender/issues/22