### PR TITLE
BEG-202: Added Missing Import

### DIFF
--- a/Model/Url/GetUrlsForProducts.php
+++ b/Model/Url/GetUrlsForProducts.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Aligent\Prerender\Model\Url;
 
+use Aligent\Prerender\Helper\Config;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\App\Emulation;
 use Magento\Store\Model\Store;


### PR DESCRIPTION
- Added missing import 

Received error during setup di compile :arrow_down: 
``` 
  In GetParameterClassTrait.php line 34:                                                     
  Class "Aligent\Prerender\Model\Url\Config" does not exist                                                               
```

